### PR TITLE
Rework_vanquish_conquer

### DIFF
--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -2712,7 +2712,7 @@ public class UnitTypes{
                 heatColor = Color.valueOf("f9350f");
                 cooldownTime = 80f;
 
-                bullet = new BasicBulletType(8f, 190){{
+                bullet = new BasicBulletType(8f, 210){{
                     sprite = "missile-large";
                     width = 9.5f;
                     height = 13f;
@@ -2720,25 +2720,21 @@ public class UnitTypes{
                     hitSize = 6f;
                     shootEffect = Fx.shootTitan;
                     smokeEffect = Fx.shootSmokeTitan;
-                    pierceCap = 2;
-                    pierce = true;
-                    pierceBuilding = true;
                     hitColor = backColor = trailColor = Color.valueOf("feb380");
                     frontColor = Color.white;
                     trailWidth = 3.1f;
                     trailLength = 8;
                     hitEffect = despawnEffect = Fx.blastExplosion;
-                    splashDamageRadius = 20f;
-                    splashDamage = 50f;
+                    splashDamageRadius = 16f;
+                    splashDamage = 80f;
 
-                    fragOnHit = false;
                     fragRandomSpread = 0f;
-                    fragSpread = 10f;
+                    fragSpread = 12f;
                     fragBullets = 5;
                     fragVelocityMin = 1f;
                     despawnSound = Sounds.dullExplosion;
 
-                    fragBullet = new ArtilleryBulletType(4f, 35){{
+                    fragBullet = new ArtilleryBulletType(4f, 45){{
                         sprite = "missile-large";
                         width = 8f;
                         height = 12f;
@@ -2749,7 +2745,7 @@ public class UnitTypes{
                         trailWidth = 2.8f;
                         trailLength = 6;
                         hitEffect = despawnEffect = Fx.blastExplosion;
-                        splashDamageRadius = 32f;
+                        splashDamageRadius = 36f;
                         splashDamage = 40f;
                     }};
                 }};
@@ -2767,7 +2763,7 @@ public class UnitTypes{
                     rotate = true;
                     rotateSpeed = 2.6f;
 
-                    bullet = new BasicBulletType(6f, 36f){{
+                    bullet = new BasicBulletType(6f, 40f){{
                         width = 6.5f;
                         height = 11f;
                         shootEffect = Fx.sparkShoot;
@@ -2869,7 +2865,7 @@ public class UnitTypes{
                     }});
                 }
 
-                bullet = new BasicBulletType(7f, 500f){{
+                bullet = new BasicBulletType(7f, 420f){{
                     sprite = "missile-large";
                     width = 12f;
                     height = 20f;
@@ -2879,7 +2875,7 @@ public class UnitTypes{
                     smokeEffect = Fx.shootSmokeTitan;
                     pierceCap = 5;
                     pierce = true;
-                    pierceBuilding = true;
+                    collidesTiles = false;
                     hitColor = backColor = trailColor = Color.valueOf("feb380");
                     frontColor = Color.white;
                     trailWidth = 4f;
@@ -2910,7 +2906,7 @@ public class UnitTypes{
                                 hitSize = 5f;
                                 pierceCap = 2;
                                 pierce = true;
-                                pierceBuilding = true;
+                                collidesTiles = false;
                                 hitColor = backColor = trailColor = Color.valueOf("feb380");
                                 frontColor = Color.white;
                                 trailWidth = 2.5f;

--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -2712,7 +2712,7 @@ public class UnitTypes{
                 heatColor = Color.valueOf("f9350f");
                 cooldownTime = 80f;
 
-                bullet = new BasicBulletType(8f, 210f){{
+                bullet = new BasicBulletType(8f, 240f){{
                     sprite = "missile-large";
                     width = 9.5f;
                     height = 13f;
@@ -2865,7 +2865,7 @@ public class UnitTypes{
                     }});
                 }
 
-                bullet = new BasicBulletType(7f, 380f){{
+                bullet = new BasicBulletType(7f, 460f){{
                     sprite = "missile-large";
                     width = 12f;
                     height = 20f;
@@ -2914,7 +2914,7 @@ public class UnitTypes{
                                 weaveScale = 3f;
                                 weaveMag = 2f;
 
-                                splashDamage = 50f;
+                                splashDamage = 70f;
                                 splashDamageRadius = 40f;
                                 despawnEffect = new ExplosionEffect(){{
                                     lifetime = 30f;
@@ -2931,7 +2931,7 @@ public class UnitTypes{
                                     sparkStroke = 1.5f;
                                 }};
                             }};
-                    bulletInterval = 6f;
+                    bulletInterval = 5f;
                     intervalRandomSpread = 0f;
                     intervalBullets = 2;
                     intervalAngle = 180f;

--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -2897,15 +2897,13 @@ public class UnitTypes{
                         sparkStroke = 3f;
                     }};
 
-                    intervalBullet = new BasicBulletType(2f, 40f){{
+                    intervalBullet = new BasicBulletType(2f, 20f){{
                                 drag = 0.01f;
                                 width = 12f;
                                 height = 11f;
                                 lifetime = 27f;
                                 weaveRandom = false;
                                 hitSize = 5f;
-                                pierceCap = 2;
-                                pierce = true;
                                 collidesTiles = false;
                                 hitColor = backColor = trailColor = Color.valueOf("feb380");
                                 frontColor = Color.white;
@@ -2914,7 +2912,7 @@ public class UnitTypes{
                                 weaveScale = 3f;
                                 weaveMag = 2f;
 
-                                splashDamage = 70f;
+                                splashDamage = 140f;
                                 splashDamageRadius = 40f;
                                 despawnEffect = new ExplosionEffect(){{
                                     lifetime = 30f;

--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -2688,12 +2688,14 @@ public class UnitTypes{
             hitSize = 28f;
             treadPullOffset = 4;
             speed = 0.63f;
+            rotateSpeed = 1.3f;
             health = 11000;
             armor = 20f;
             itemCapacity = 0;
             crushDamage = 13f / 5f;
             treadRects = new Rect[]{new Rect(22 - 154f/2f, 16 - 154f/2f, 28, 130)};
-
+            hovering = true;
+            
             weapons.add(new Weapon("vanquish-weapon"){{
                 shootSound = Sounds.mediumCannon;
                 layerOffset = 0.0001f;
@@ -2702,7 +2704,7 @@ public class UnitTypes{
                 shake = 5f;
                 recoil = 4f;
                 rotate = true;
-                rotateSpeed = 1f;
+                rotateSpeed = 1.2f;
                 mirror = false;
                 x = 0f;
                 y = 0;
@@ -2714,7 +2716,7 @@ public class UnitTypes{
                     sprite = "missile-large";
                     width = 9.5f;
                     height = 13f;
-                    lifetime = 18f;
+                    lifetime = 23f;
                     hitSize = 6f;
                     shootEffect = Fx.shootTitan;
                     smokeEffect = Fx.shootSmokeTitan;
@@ -2736,19 +2738,19 @@ public class UnitTypes{
                     fragVelocityMin = 1f;
                     despawnSound = Sounds.dullExplosion;
 
-                    fragBullet = new BasicBulletType(8f, 35){{
+                    fragBullet = new ArtilleryBulletType(4f, 35){{
                         sprite = "missile-large";
                         width = 8f;
                         height = 12f;
-                        lifetime = 15f;
+                        lifetime = 12f;
                         hitSize = 4f;
                         hitColor = backColor = trailColor = Color.valueOf("feb380");
                         frontColor = Color.white;
                         trailWidth = 2.8f;
                         trailLength = 6;
                         hitEffect = despawnEffect = Fx.blastExplosion;
-                        splashDamageRadius = 10f;
-                        splashDamage = 20f;
+                        splashDamageRadius = 32f;
+                        splashDamage = 40f;
                     }};
                 }};
             }});
@@ -2757,15 +2759,15 @@ public class UnitTypes{
             for(float f : new float[]{34f / 4f, -36f / 4f}){
                 int fi = i ++;
                 weapons.add(new Weapon("vanquish-point-weapon"){{
-                    reload = 35f + fi * 5;
+                    reload = 20f;
                     x = 48f / 4f;
                     y = f;
                     shootY = 5.5f;
                     recoil = 2f;
                     rotate = true;
-                    rotateSpeed = 2f;
+                    rotateSpeed = 2.6f;
 
-                    bullet = new BasicBulletType(4.5f, 25){{
+                    bullet = new BasicBulletType(6f, 36f){{
                         width = 6.5f;
                         height = 11f;
                         shootEffect = Fx.sparkShoot;
@@ -2781,26 +2783,26 @@ public class UnitTypes{
         }};
 
         conquer = new TankUnitType("conquer"){{
-            hitSize = 46f;
+            hitSize = 42f;
             treadPullOffset = 1;
-            speed = 0.48f;
+            speed = 0.65f;
             health = 22000;
-            armor = 26f;
-            crushDamage = 25f / 5f;
-            rotateSpeed = 0.8f;
-
+            armor = 45f;
+            crushDamage = 5f;
+            rotateSpeed = 1.1f;
+            hovering = true;
             float xo = 231f/2f, yo = 231f/2f;
             treadRects = new Rect[]{new Rect(27 - xo, 152 - yo, 56, 73), new Rect(24 - xo, 51 - 9 - yo, 29, 17), new Rect(59 - xo, 18 - 9 - yo, 39, 19)};
 
             weapons.add(new Weapon("conquer-weapon"){{
                 shootSound = Sounds.largeCannon;
                 layerOffset = 0.1f;
-                reload = 100f;
+                reload = 120f;
                 shootY = 32.5f;
                 shake = 5f;
                 recoil = 5f;
                 rotate = true;
-                rotateSpeed = 0.6f;
+                rotateSpeed = 1.4f;
                 mirror = false;
                 x = 0f;
                 y = -2f;
@@ -2867,15 +2869,15 @@ public class UnitTypes{
                     }});
                 }
 
-                bullet = new BasicBulletType(8f, 360f){{
+                bullet = new BasicBulletType(7f, 400f){{
                     sprite = "missile-large";
                     width = 12f;
                     height = 20f;
-                    lifetime = 35f;
+                    lifetime = 40f;
                     hitSize = 6f;
 
                     smokeEffect = Fx.shootSmokeTitan;
-                    pierceCap = 3;
+                    pierceCap = 5;
                     pierce = true;
                     pierceBuilding = true;
                     hitColor = backColor = trailColor = Color.valueOf("feb380");
@@ -2899,18 +2901,11 @@ public class UnitTypes{
                         sparkStroke = 3f;
                     }};
 
-                    int count = 6;
-                    for(int j = 0; j < count; j++){
-                        int s = j;
-                        for(int i : Mathf.signs){
-                            float fin = 0.05f + (j + 1) / (float)count;
-                            float spd = speed;
-                            float life = lifetime / Mathf.lerp(fin, 1f, 0.5f);
-                            spawnBullets.add(new BasicBulletType(spd * fin, 60){{
+                    intervalBullet = new BasicBulletType(1f, 60f){{
                                 drag = 0.002f;
                                 width = 12f;
                                 height = 11f;
-                                lifetime = life + 5f;
+                                lifetime = 30f;
                                 weaveRandom = false;
                                 hitSize = 5f;
                                 pierceCap = 2;
@@ -2920,11 +2915,11 @@ public class UnitTypes{
                                 frontColor = Color.white;
                                 trailWidth = 2.5f;
                                 trailLength = 7;
-                                weaveScale = (3f + s/2f) / 1.2f;
-                                weaveMag = i * (4f - fin * 2f);
+                                weaveScale = 3f;
+                                weaveMag = 2f;
 
                                 splashDamage = 65f;
-                                splashDamageRadius = 30f;
+                                splashDamageRadius = 40f;
                                 despawnEffect = new ExplosionEffect(){{
                                     lifetime = 50f;
                                     waveStroke = 4f;
@@ -2939,7 +2934,12 @@ public class UnitTypes{
                                     sparkLen = 3f;
                                     sparkStroke = 1.5f;
                                 }};
-                            }});
+                            }};
+                    bulletInterval = 3f;
+                    intervalRandomSpread = 0f;
+                    intervalBullets = 2;
+                    intervalAngle = 180f;
+                    intervalSpread = 330f;
                         }
                     }
                 }};

--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -2712,7 +2712,7 @@ public class UnitTypes{
                 heatColor = Color.valueOf("f9350f");
                 cooldownTime = 80f;
 
-                bullet = new BasicBulletType(8f, 210){{
+                bullet = new BasicBulletType(8f, 210f){{
                     sprite = "missile-large";
                     width = 9.5f;
                     height = 13f;
@@ -2734,7 +2734,7 @@ public class UnitTypes{
                     fragVelocityMin = 1f;
                     despawnSound = Sounds.dullExplosion;
 
-                    fragBullet = new ArtilleryBulletType(4f, 45){{
+                    fragBullet = new ArtilleryBulletType(4f, 45f){{
                         sprite = "missile-large";
                         width = 8f;
                         height = 12f;
@@ -2897,8 +2897,8 @@ public class UnitTypes{
                         sparkStroke = 3f;
                     }};
 
-                    intervalBullet = new BasicBulletType(1f, 40f){{
-                                drag = 0.002f;
+                    intervalBullet = new BasicBulletType(2f, 40f){{
+                                drag = 0.01f;
                                 width = 12f;
                                 height = 11f;
                                 lifetime = 30f;
@@ -2931,7 +2931,7 @@ public class UnitTypes{
                                     sparkStroke = 1.5f;
                                 }};
                             }};
-                    bulletInterval = 3f;
+                    bulletInterval = 4f;
                     intervalRandomSpread = 0f;
                     intervalBullets = 2;
                     intervalAngle = 180f;

--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -2734,7 +2734,7 @@ public class UnitTypes{
                     fragVelocityMin = 1f;
                     despawnSound = Sounds.dullExplosion;
 
-                    fragBullet = new ArtilleryBulletType(4f, 45f){{
+                    fragBullet = new ArtilleryBulletType(3f, 45f){{
                         sprite = "missile-large";
                         width = 8f;
                         height = 12f;
@@ -2745,8 +2745,8 @@ public class UnitTypes{
                         trailWidth = 2.8f;
                         trailLength = 6;
                         hitEffect = despawnEffect = Fx.blastExplosion;
-                        splashDamageRadius = 36f;
-                        splashDamage = 40f;
+                        splashDamageRadius = 32f;
+                        splashDamage = 50f;
                     }};
                 }};
             }});
@@ -2865,7 +2865,7 @@ public class UnitTypes{
                     }});
                 }
 
-                bullet = new BasicBulletType(7f, 420f){{
+                bullet = new BasicBulletType(7f, 380f){{
                     sprite = "missile-large";
                     width = 12f;
                     height = 20f;
@@ -2883,7 +2883,7 @@ public class UnitTypes{
                     hitEffect = despawnEffect = Fx.massiveExplosion;
 
                     shootEffect = new ExplosionEffect(){{
-                        lifetime = 40f;
+                        lifetime = 32f;
                         waveStroke = 4f;
                         waveColor = sparkColor = trailColor;
                         waveRad = 15f;
@@ -2901,7 +2901,7 @@ public class UnitTypes{
                                 drag = 0.01f;
                                 width = 12f;
                                 height = 11f;
-                                lifetime = 30f;
+                                lifetime = 27f;
                                 weaveRandom = false;
                                 hitSize = 5f;
                                 pierceCap = 2;
@@ -2914,10 +2914,10 @@ public class UnitTypes{
                                 weaveScale = 3f;
                                 weaveMag = 2f;
 
-                                splashDamage = 60f;
+                                splashDamage = 50f;
                                 splashDamageRadius = 40f;
                                 despawnEffect = new ExplosionEffect(){{
-                                    lifetime = 50f;
+                                    lifetime = 30f;
                                     waveStroke = 4f;
                                     waveColor = sparkColor = trailColor;
                                     waveRad = 30f;
@@ -2931,7 +2931,7 @@ public class UnitTypes{
                                     sparkStroke = 1.5f;
                                 }};
                             }};
-                    bulletInterval = 4f;
+                    bulletInterval = 6f;
                     intervalRandomSpread = 0f;
                     intervalBullets = 2;
                     intervalAngle = 180f;

--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -2690,7 +2690,7 @@ public class UnitTypes{
             speed = 0.63f;
             rotateSpeed = 1.3f;
             health = 11000;
-            armor = 20f;
+            armor = 26f;
             itemCapacity = 0;
             crushDamage = 13f / 5f;
             treadRects = new Rect[]{new Rect(22 - 154f/2f, 16 - 154f/2f, 28, 130)};
@@ -2759,7 +2759,7 @@ public class UnitTypes{
             for(float f : new float[]{34f / 4f, -36f / 4f}){
                 int fi = i ++;
                 weapons.add(new Weapon("vanquish-point-weapon"){{
-                    reload = 20f;
+                    reload = 15f;
                     x = 48f / 4f;
                     y = f;
                     shootY = 5.5f;
@@ -2869,7 +2869,7 @@ public class UnitTypes{
                     }});
                 }
 
-                bullet = new BasicBulletType(7f, 400f){{
+                bullet = new BasicBulletType(7f, 500f){{
                     sprite = "missile-large";
                     width = 12f;
                     height = 20f;
@@ -2901,7 +2901,7 @@ public class UnitTypes{
                         sparkStroke = 3f;
                     }};
 
-                    intervalBullet = new BasicBulletType(1f, 60f){{
+                    intervalBullet = new BasicBulletType(1f, 40f){{
                                 drag = 0.002f;
                                 width = 12f;
                                 height = 11f;
@@ -2918,7 +2918,7 @@ public class UnitTypes{
                                 weaveScale = 3f;
                                 weaveMag = 2f;
 
-                                splashDamage = 65f;
+                                splashDamage = 60f;
                                 splashDamageRadius = 40f;
                                 despawnEffect = new ExplosionEffect(){{
                                     lifetime = 50f;

--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -2695,6 +2695,7 @@ public class UnitTypes{
             crushDamage = 13f / 5f;
             treadRects = new Rect[]{new Rect(22 - 154f/2f, 16 - 154f/2f, 28, 130)};
             hovering = true;
+            canDrown = false;
             
             weapons.add(new Weapon("vanquish-weapon"){{
                 shootSound = Sounds.mediumCannon;
@@ -2766,6 +2767,7 @@ public class UnitTypes{
                     bullet = new BasicBulletType(6f, 40f){{
                         width = 6.5f;
                         height = 11f;
+                        lifetime = 22f;
                         shootEffect = Fx.sparkShoot;
                         smokeEffect = Fx.shootBigSmoke;
                         hitColor = backColor = trailColor = Color.valueOf("feb380");
@@ -2787,6 +2789,7 @@ public class UnitTypes{
             crushDamage = 5f;
             rotateSpeed = 1.1f;
             hovering = true;
+            canDrown = false;
             float xo = 231f/2f, yo = 231f/2f;
             treadRects = new Rect[]{new Rect(27 - xo, 152 - yo, 56, 73), new Rect(24 - xo, 51 - 9 - yo, 29, 17), new Rect(59 - xo, 18 - 9 - yo, 39, 19)};
 
@@ -2865,15 +2868,15 @@ public class UnitTypes{
                     }});
                 }
 
-                bullet = new BasicBulletType(7f, 460f){{
+                bullet = new BasicBulletType(8f, 460f){{
                     sprite = "missile-large";
                     width = 12f;
                     height = 20f;
-                    lifetime = 40f;
+                    lifetime = 35f;
                     hitSize = 6f;
 
                     smokeEffect = Fx.shootSmokeTitan;
-                    pierceCap = 5;
+                    pierceCap = 3;
                     pierce = true;
                     collidesTiles = false;
                     hitColor = backColor = trailColor = Color.valueOf("feb380");
@@ -2912,8 +2915,8 @@ public class UnitTypes{
                                 weaveScale = 3f;
                                 weaveMag = 2f;
 
-                                splashDamage = 140f;
-                                splashDamageRadius = 40f;
+                                splashDamage = 120f;
+                                splashDamageRadius = 36f;
                                 despawnEffect = new ExplosionEffect(){{
                                     lifetime = 30f;
                                     waveStroke = 4f;

--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -2940,8 +2940,7 @@ public class UnitTypes{
                     intervalBullets = 2;
                     intervalAngle = 180f;
                     intervalSpread = 330f;
-                        }
-                    }
+
                 }};
             }});
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,4 +26,4 @@ org.gradle.caching=true
 org.gradle.internal.http.socketTimeout=100000
 org.gradle.internal.http.connectionTimeout=100000
 android.enableR8.fullMode=false
-archash=deacd9c98e
+archash=aa4a6cd37c


### PR DESCRIPTION
Both tanks got slightly better moving speed & rotation speed. Armor increased.

Getting ability to travel on liquid assuming these units are big enough to float, offering mobility (can travel on liquid but cannot cross wall) in between mech & ship.

Weapons' anti-wall capability improved, fire power & aiming speed increased.

Vanquish frags become artillery bullets that could fly over blocks but with limited range to avoid missing targets near the one hit by main bullet.

Conquer fires a lot more interval bullets while the main bullet flies over blocks(not collide tiles) but could get blocked by enough units due to its 3x pierce cap.

<img width="291" alt="image" src="https://github.com/user-attachments/assets/c4307dd4-b457-4a19-95d3-78031689619c" />
 
<img width="431" alt="image" src="https://github.com/user-attachments/assets/0b9fc509-ddca-40b1-9675-a8ac40051dfc" />

![vanq1](https://github.com/user-attachments/assets/c633175a-4991-40c7-b5d6-67f7f2393f03)

![conq](https://github.com/user-attachments/assets/1ac68838-c92f-41df-bd30-c503f3d84142)

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
